### PR TITLE
Bump to development version and record #147 in NEWS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: animovement
 Type: Package
 Title: An R toolbox for analysing movement across space and time
-Version: 0.7.3
+Version: 0.7.3.9000
 Authors@R: 
     person(
       "Mikkel", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# animovement (development version)
+
+* `animovement_update()`, `animovement_install()` and `animovement_deps()` now look in the animovement r-universe by default, via the new `animovement_repos()`, instead of failing unless `repos` was set by hand (#144).
+* `animovement_install_suggested()` works again: it no longer passes an unsupported `repos` argument to `pak::pkg_install()`, and finds `rhdf5` on the Bioconductor r-universe (#146).
+* Installation under webR goes through `webr::install()` for every install function, not just `animovement_install_suggested()` (#139).
+* Suggested packages no longer include development tooling, or packages already required by the suite, cutting the set from 21 to 8 (#143).
+
 # animovement 0.7.3
 
 * Added `here` and `signal` to Suggests, and `circular` for `summarise_aniframe()`.


### PR DESCRIPTION
Follow-up to #147, which merged without a version bump or NEWS entry.

- `DESCRIPTION`: `0.7.3` → `0.7.3.9000`, since 0.7.3 is released and development continues from there.
- `NEWS.md`: a `# animovement (development version)` section, matching the heading style aniread and aniframe use for unreleased work.

The four bullets cover the user-visible changes from #147, each pointing at the issue it closes (#144, #146, #139, #143). Internal changes — the roxygen2 8.1 migration, the CI workflow alignment, and the new test-coverage job — are left out as they are not user-facing.

Documentation work is tracked separately in #148.