### PR TITLE
Use the static Zenodo DOI badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <!-- badges: start -->
 
-[![DOI](https://zenodo.org/badge/773406370.svg)](https://zenodo.org/doi/10.5281/zenodo.13235277)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.13235277.svg)](https://doi.org/10.5281/zenodo.13235277)
 [![R-CMD-check](https://github.com/animovement/animovement/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/animovement/animovement/actions/workflows/R-CMD-check.yaml)
 [![animovement status
 badge](https://animovement.r-universe.dev/badges/animovement)](https://animovement.r-universe.dev)

--- a/README.qmd
+++ b/README.qmd
@@ -27,7 +27,7 @@ options(animovement.styling = FALSE)
 
 <!-- badges: start -->
 
-[![DOI](https://zenodo.org/badge/773406370.svg)](https://zenodo.org/doi/10.5281/zenodo.13235277)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.13235277.svg)](https://doi.org/10.5281/zenodo.13235277)
 [![R-CMD-check](https://github.com/animovement/animovement/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/animovement/animovement/actions/workflows/R-CMD-check.yaml)
 [![animovement status
 badge](https://animovement.r-universe.dev/badges/animovement)](https://animovement.r-universe.dev)


### PR DESCRIPTION
The DOI badge was using the repository-ID form, `zenodo.org/badge/773406370.svg`. Zenodo generates that one on request and answers with a 302 before serving anything, so it renders slowly and often not at all.

This switches to the static DOI badge the rest of the ecosystem already uses (aniread, aniprocess, animetric, anicheck), and points the link at the doi.org resolver rather than the Zenodo URL:

```
[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.13235277.svg)](https://doi.org/10.5281/zenodo.13235277)
```

Measured side by side:

| badge | response | time |
| --- | --- | --- |
| `badge/773406370.svg` (before) | 302 | 0.34s |
| `badge/DOI/10.5281/zenodo.13235277.svg` (after) | 200 | 0.18s |

Same concept DOI, so it still resolves to all versions. README.md re-rendered from README.qmd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)