### PR TITLE
Bump to a development version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: animovement
 Type: Package
 Title: An R toolbox for analysing movement across space and time
-Version: 0.7.4
+Version: 0.7.4.9000
 Authors@R: c(
     person(
       "Mikkel", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,10 @@
+# animovement (development version)
+
 # animovement 0.7.4
+
+* The licence declaration is corrected from `GPL-3 + file LICENSE` to `GPL-3`, with the full text as `LICENSE.md`. The `+ file LICENSE` form asserts additional restrictions beyond GPL-3, and the file held nothing but the stock GPL-3 text. The licence that applies is unchanged; only how it is declared. `CITATION.cff` said `MIT`, left over from before the metapackage was rebuilt on the fastverse pattern, and now agrees at `GPL-3.0-only`.
+* Sebastian Krantz (fastverse) and Hadley Wickham (tidyverse) are credited as contributors, for the package management code adapted from the fastverse.
+* The DOI badge now uses the static Zenodo badge rather than the repository-ID one, which answered a redirect before serving anything and often failed to render.
 
 * Documentation is now scoped to the meta-package itself. The ecosystem tutorials have moved to [animovement.dev](https://animovement.dev); the README and the introductory vignette now cover attaching the suite, conflicts, `.animovement` project configuration, extending, updating, and suggested packages (#136, #148).
 * Dropped `rhdf5` and the Bioconductor r-universe from `Suggests` — it was only needed by the tutorials that have moved. `animovement_install_suggested()` still resolves it for the ecosystem packages that suggest it.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ When loading the package, the versions and any conflicts are listed:
 
 ``` r
 library(animovement)
-#> -- Attaching packages ------------------------------------- animovement 0.7.4 --
+#> -- Attaching packages -------------------------------- animovement 0.7.4.9000 --
 #> v aniframe   0.7.0.9000     v anicheck   0.2.0     
 #> v aniread    0.6.0.9000     v animetric  0.4.0     
 #> v anispace   0.2.0          v anivis     0.2.0     


### PR DESCRIPTION
Follows the v0.7.4 tag and [release](https://github.com/animovement/animovement/releases/tag/v0.7.4), cut from 38ed258.

- `DESCRIPTION`: `0.7.4` → `0.7.4.9000`, so the next commits land on a development version rather than on top of a release
- `NEWS.md`: opens a development section
- `README.md`: re-rendered, since the startup banner embeds the version

It also backfills three entries under `0.7.4` that landed in #152 after the NEWS entry had been written — the licence declaration correction, the fastverse/tidyverse attribution, and the DOI badge fix. They are described in the release notes but were missing from `NEWS.md`, so `NEWS.md` on main now matches what actually shipped. The `v0.7.4` tag itself is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)