### PR TITLE
Add the shared pr-commands workflow

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -1,85 +1,15 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# Handles /document and /style comments on pull requests. The workflow lives in
+# animovement/.github so it is maintained in one place; only the trigger is
+# declared here.
+name: pr-commands
+
 on:
   issue_comment:
     types: [created]
 
-name: pr-commands.yaml
-
-permissions: read-all
-
 jobs:
-  document:
-    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/document') }}
-    name: document
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+  pr-commands:
+    uses: animovement/.github/.github/workflows/pr-commands.yml@main
     permissions:
       contents: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/pr-fetch@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::roxygen2
-          needs: pr-document
-
-      - name: Document
-        run: roxygen2::roxygenise()
-        shell: Rscript {0}
-
-      - name: commit
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add man/\* NAMESPACE
-          git commit -m 'Document'
-
-      - uses: r-lib/actions/pr-push@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-  style:
-    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/style') }}
-    name: style
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/pr-fetch@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: r-lib/actions/setup-r@v2
-
-      - name: Install dependencies
-        run: install.packages("styler")
-        shell: Rscript {0}
-
-      - name: Style
-        run: styler::style_pkg()
-        shell: Rscript {0}
-
-      - name: commit
-        run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add \*.R
-          git commit -m 'Style'
-
-      - uses: r-lib/actions/pr-push@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
Adds the `/document` and `/style` pull request commands, calling the shared workflow in [`animovement/.github`](https://github.com/animovement/.github/pull/5).

**Merge [animovement/.github#5](https://github.com/animovement/.github/pull/5) first.** This stub fails until the shared workflow is on `main` there.

Commenting `/document` on a pull request re-runs roxygen and pushes the result; `/style` reformats with air and pushes. Both are restricted to comments by a MEMBER or OWNER, so an outside comment cannot cause a push.

This workflow previously existed only in `animovement`, so for the other packages it is a new capability rather than a move. Its `/style` job now runs **air** rather than styler, matching the `format-suggest` workflow that already runs on every pull request here — see the shared PR for why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
