### PR TITLE
Household sweep: logo, badges, citations, DOIs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,15 +8,18 @@ message: 'To cite package "animovement" in publications use:'
 type: software
 license: GPL-3.0-only
 title: 'animovement: An R toolbox for analysing movement across space and time.'
-version: 0.7.4
+version: 0.7.4.9000
 date-released: 2026-08-19
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.13235277
 abstract: An R toolbox for analysing movement across space and time.
 authors:
 - family-names: Roald-Arbøl
   given-names: Mikkel
   email: animovement.84w1m@passmail.com
   orcid: https://orcid.org/0000-0002-9998-0058
-url: http://animovement.dev/animovement/
+url: https://animovement.dev/animovement/
 contact:
 - family-names: Roald-Arbøl
   given-names: Mikkel

--- a/README.md
+++ b/README.md
@@ -198,20 +198,21 @@ If you enjoy the package, please make sure to cite it. To cite
 
 ``` r
 citation("animovement")
-#> To cite package 'animovement' in publications use:
+#> To cite the animovement toolbox in publications use:
 #> 
 #>   Roald-Arbøl M (2026). "animovement: An R toolbox for analysing
-#>   movement across space and time."
+#>   movement across space and time." doi:10.5281/zenodo.13235277
+#>   <https://doi.org/10.5281/zenodo.13235277>.
 #>   <https://animovement.dev/animovement/>.
 #> 
 #> A BibTeX entry for LaTeX users is
 #> 
-#>   @Misc{roaldarbol:2025,
-#>     title = {animovement: An R toolbox for analysing movement across space and time.},
+#>   @Misc{animovement,
+#>     title = {animovement: An R toolbox for analysing movement across space and time},
 #>     author = {Mikkel Roald-Arbøl},
 #>     year = {2026},
+#>     doi = {10.5281/zenodo.13235277},
+#>     version = {0.7.4.9000},
 #>     url = {https://animovement.dev/animovement/},
-#>     abstract = {An R toolbox for analysing movement across space and time.},
-#>     version = {0.7.4},
 #>   }
 ```

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: http://animovement.dev/animovement/
+url: https://animovement.dev/animovement/
 
 home:
   title: Analyse movement across space and time

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,12 +1,17 @@
+citHeader(
+  "To cite the animovement toolbox in publications use:"
+)
 
-bibentry(bibtype = "Misc",
-         key = "roaldarbol:2025",
-         title = "animovement: An R toolbox for analysing movement across space and time.",
-         author = person(given = "Mikkel",
-                         family = "Roald-Arbøl",
-                         email = "animovement.84w1m@passmail.com",
-                         comment = c(ORCID = "0000-0002-9998-0058")),
-         year = "2026",
-         url = "https://animovement.dev/animovement/",
-         abstract = "An R toolbox for analysing movement across space and time.",
-         version = "0.7.4")
+bibentry(
+  bibtype  = "Misc",
+  key      = "animovement",
+  title    = "animovement: An R toolbox for analysing movement across space and time",
+  author   = person(
+    given = "Mikkel", family = "Roald-Arbøl",
+    comment = c(ORCID = "0000-0002-9998-0058")
+  ),
+  year     = "2026",
+  doi      = "10.5281/zenodo.13235277",
+  version  = meta$Version,
+  url      = "https://animovement.dev/animovement/"
+)


### PR DESCRIPTION
Housekeeping sweep applied identically across all eight packages, so they line up.

## The serious one: DOIs

Three packages were advertising **another package's DOI**, so `citation()` credited the wrong software:

| package | was | now |
| --- | --- | --- |
| anispace | `zenodo.17344597/8` — **aniframe's** | `zenodo.21996854` |
| animetric | `zenodo.17357778` — **aniprocess's** | `zenodo.17818613` |
| anivis | `zenodo.17344598` — **aniframe's** (in `inst/CITATION`) | `zenodo.21030691` |

Everywhere else the DOI was the package's own, but **version-specific rather than concept**, so it pinned a citation to one release instead of the software as a whole. All eight now use the concept DOI, verified against the Zenodo API — a concept DOI is the one that redirects to the latest version.

Two links were also malformed: aniframe and anispace linked to `(10.5281/zenodo.…)` with no `https://doi.org/`, which GitHub treats as a relative path.

## Citations

`inst/CITATION` now offers both citations, ecosystem first:

```
To cite anispace in publications, please cite the animovement toolbox as a
whole (the first entry below). If your work used only anispace, you may
cite the package directly instead (the second entry).

  Roald-Arbøl M (2026). "animovement: An R toolbox for analysing movement
  across space and time." doi:10.5281/zenodo.13235277

  Roald-Arbøl M (2026). "anispace: An R package providing spatial
  transformation methods for movement data." doi:10.5281/zenodo.21996854
```

The package version comes from `meta$Version`, so it tracks `DESCRIPTION` rather than going stale. anicheck had no `inst/CITATION` at all and now has one. `CITATION.cff` gets the same concept DOI, and its `version` is brought back in step with `DESCRIPTION` — anivis and anicheck both still said `0.1.0`.

Rendering was checked with `utils::readCitationFile()` before pushing, since a malformed `inst/CITATION` breaks `citation()` and `R CMD check`.

## Also

- **Logo** added at `man/figures/logo.png` (240px, from the ecosystem hex set) and `logo.svg`, and placed in the README title. pkgdown picks these up for the site and favicons.
- **DOI badge** switched to the static form everywhere. anicheck and anivis were using the repository-ID badge, which 302-redirects before serving anything and often fails to render.
- **Badge set** made consistent: DOI, R-CMD-check, r-universe, codecov, Zulip. anicheck, anispace and animetric were missing the Zulip badge.
- **"Early development" warning** removed from anicheck, anispace, animetric and anivis.
- **`_pkgdown.yml` url** changed from `http://` to `https://`. This is why every generated link in `llms.txt` and the reference pages currently points at `http://animovement.dev/…` and redirects.

## Note

`README.md` is **not** regenerated here — that needs `devtools::build_readme()` or `quarto render` with the package installed. Worth doing before merging, or the rendered README will still show the old badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update: `README.md` is regenerated here, and the source is migrated to Quarto.**

You do not need to run `build_readme()` before merging — the rendered `README.md` is in this pull request, produced by installing this branch's source so the citation block reflects the new `inst/CITATION` rather than the published build.

`README.Rmd` becomes **`README.qmd`**, matching the metapackage, with `.Rbuildignore` updated to suit. The Quarto header carries `default-image-extension: ""`, without which pandoc appends `.png` to extensionless image URLs and silently breaks every shields.io and R-universe badge — verified absent in the rendered output.

Two further defects found while rendering:

- **The citation never rendered.** In anicheck, anispace, animetric and anivis the `citation()` chunk was `eval=FALSE`, so the README showed an empty code block where the citation should be. Now evaluated, and the rendered output carries both entries.
- **`install.packages()` was running on every render.** aniframe and aniread had a live `install.packages(...)` call inside the hidden setup chunk, so rendering the README reinstalled the package from R-universe, overwriting the local build and rendering the *published* citation rather than the source's. Removed. In the other five the same line was commented out and harmless.